### PR TITLE
Symfony 4.4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "dneustadt/csrf-cookie-bundle",
   "type": "symfony-bundle",
   "description": "CSRF protection cookie for use with XHR",
-  "keywords": ["csrf", "xsrf", "security", "angular", "react", "vue.js", "axios", "ajax", "xhr"],
+  "keywords": ["csrf", "xsrf", "security", "angular", "react", "vue.js", "axios", "ajax", "xhr", "symfony", "bundle"],
   "homepage": "https://neustadt.dev",
   "license": "MIT",
   "authors": [
@@ -13,12 +13,12 @@
     }
   ],
   "require": {
-    "php": ">=7.2.5",
-    "symfony/config": "^5.0",
-    "symfony/dependency-injection": "^5.0",
-    "symfony/http-foundation": "^5.0",
-    "symfony/http-kernel": "^5.0",
-    "symfony/security-csrf": "^5.0"
+    "php": ">=7.1.3",
+    "symfony/config": "^4.4|^5.0",
+    "symfony/dependency-injection": "^4.4|^5.0",
+    "symfony/http-foundation": "^4.4|^5.0",
+    "symfony/http-kernel": "^4.4|^5.0",
+    "symfony/security-csrf": "^4.4|^5.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This PR adds compatibility with Symfony 4.4. It also lowers the PHP requirement from `7.2.5` to `7.1.3` to match Symfony 4.4's minimum.
Also added the `symfony` and  `bundle` keywords in composer.json; of course, they're not necessary, it's just a bit of SEO for the bundle.

On a side note, I think the bundle could easily also be compatible with Symfony 4.2 (that's when Symfony started handling the  `SameSite` cookie attribute), although I don't see a point since [Symfony 4.2 and 4.3 are already unmaintained](https://symfony.com/releases). Symfony 4.4 is going to be maintained until November 2023.