### PR TITLE
Add priority for kernel.request event subscriber

### DIFF
--- a/EventSubscriber/KernelEventSubscriber.php
+++ b/EventSubscriber/KernelEventSubscriber.php
@@ -25,7 +25,7 @@ class KernelEventSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return [
-            KernelEvents::REQUEST => 'onKernelRequest',
+            KernelEvents::REQUEST => ['onKernelRequest', 12],
             KernelEvents::RESPONSE => 'onKernelResponse',
         ];
     }


### PR DESCRIPTION
Added priority for CSRF Validation Subscriber so that it still intercepts Security actions.

Ref: Same as in https://github.com/dunglas/DunglasAngularCsrfBundle/issues/18

Priority set to 12 because:
- LocaleListener 16
- Firewall 8